### PR TITLE
Fix: prepareSdCard() now asks like intended whether to install Balena…

### DIFF
--- a/AliceCli/install/install.py
+++ b/AliceCli/install/install.py
@@ -419,7 +419,7 @@ def prepareSdCard(ctx: click.Context):  # NOSONAR
 			'message': 'Balena-cli was not found on your system, do you want to install it?',
 			'name'   : 'installBalena',
 			'default': True,
-			'when'   : lambda flasherAvailable: not flasherAvailable
+			'when'   : lambda answers: not flasherAvailable
 		}
 	]
 


### PR DESCRIPTION
…, if it is not installed

- Previously the "I cannot flash your SD card" message was displayed immediately, without informing the user, what was the problem.