### PR TITLE
Convert from PyInquirer to InquirerPy

### DIFF
--- a/AliceCli/MainMenu.py
+++ b/AliceCli/MainMenu.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 
 import click
-from InquirerPy import Separator, prompt
+from InquirerPy import prompt
 
 from AliceCli.Version import Version
 from AliceCli.alice.alice import reportBug, systemctl, updateAlice

--- a/AliceCli/MainMenu.py
+++ b/AliceCli/MainMenu.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 
 import click
-from PyInquirer import Separator, prompt
+from InquirerPy import Separator, prompt
 
 from AliceCli.Version import Version
 from AliceCli.alice.alice import reportBug, systemctl, updateAlice
@@ -33,6 +33,19 @@ from AliceCli.utils.utils import aliceLogs, changeHostname, changePassword, rebo
 
 VERSION = ''
 CHECKED = False
+
+
+# Copied from https://github.com/CITGuru/PyInquirer/blob/master/PyInquirer/separator.py
+class Separator:
+    line = '-' * 15
+
+    def __init__(self, line=None):
+        if line:
+            self.line = line
+
+    def __str__(self):
+        return self.line
+
 
 @click.command(name='main_menu')
 @click.pass_context

--- a/AliceCli/install/install.py
+++ b/AliceCli/install/install.py
@@ -23,7 +23,7 @@ import requests
 import subprocess
 import time
 import yaml
-from PyInquirer import prompt
+from InquirerPy import prompt
 from bs4 import BeautifulSoup
 from pathlib import Path
 from shutil import which

--- a/AliceCli/utils/commons.py
+++ b/AliceCli/utils/commons.py
@@ -26,7 +26,7 @@ import socket
 import sys
 import time
 import uuid
-from PyInquirer import prompt
+from InquirerPy import prompt
 from networkscan import networkscan
 from pathlib import Path
 from threading import Event, Thread

--- a/AliceCli/utils/utils.py
+++ b/AliceCli/utils/utils.py
@@ -20,7 +20,7 @@
 
 import click
 import time
-from PyInquirer import prompt
+from InquirerPy import prompt
 
 from AliceCli.utils import commons
 from AliceCli.utils.decorators import checkConnection

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
 	install_requires=[
 		'click~=8.0.3',
 		'paramiko~=2.8.1',
-		'PyInquirer~=1.0.3',
+		'InquirerPy~=0.3.1',
 		'networkscan~=1.0.9',
 		'pyyaml~=6.0',
 		'requests~=2.26.0',


### PR DESCRIPTION
PyInquirer requires an old version of prompt_toolkit (1.0.14)
which imports Mapping from collections, which appears to be
deprecated. Mapping should be imported from collections.abc.
This breaks in Python 3.10. InquirerPy uses the newer version
of prompt_toolkit but lacks the Separator class.

This switches the requirement from PyInquirer to InquirerPy and
adds a copy of the Separator class to MainMenu.py.